### PR TITLE
Replace an expired Slack invite with a link to the registration form

### DIFF
--- a/index.md
+++ b/index.md
@@ -46,7 +46,7 @@ Follow our news and announcements on social media:
 Find us on the semi-official OWASP
 [Slack](https://owasp.slack.com/messages/chapter-ua/) channel (you have
 to
-[register](https://owasp.slack.com/join/shared_invite/enQtNDI5MzgxMDQ2MTAwLTEyNzIzYWQ2NDZiMGIwNmJhYzYxZDJiNTM0ZmZiZmJlY2EwZmMwYjAyNmJjNzQxNzMyMWY4OTk3ZTQ0MzFhMDY)
+[register](https://owasp.org/slack/invite)
 first)
 
 Watch recordings of our previous events


### PR DESCRIPTION
Randomly noticed that the link doesn’t work anymore. The form appears to be working (at least it said correctly that I’m already signed up — I didn’t want to create fake users just to test).